### PR TITLE
Fix issues if opts.vars is specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@ module.exports = function (file, opts) {
     if (/\.json$/.test(file)) return through();
     if (!opts) opts = {};
     var filedir = path.dirname(file);
-    var vars = opts.vars || {
-        __filename: file,
-        __dirname: filedir
-    };
+    var vars = {};
+    for (var key in opts.vars) {
+        vars[key] = opts.vars[key];
+    }
+    vars.__filename = vars.__filename || file;
+    vars.__dirname = vars.__dirname || filedir;
     
     var sm = staticModule(
         { 'bulk-require': bulkRequire },


### PR DESCRIPTION
Previously was not populating __filename and __dirname if opts.vars was specified.

My test case usage (in your examples directory):
```javascript
var browserify = require('browserify');
var b = browserify();
b.add('./glob.js');
b.transform('bulkify', { vars: { __foo: 'bar' } });
b.bundle().pipe(process.stdout);
```

This code now "works" in that it no longer generates bad output (previous code would, I think, fail to find the file being required, since __dirname was never defined, and then output nothing).  However, I can't seem to do anything useful with this (e.g. just like with `__dirname` it seems to only get replaced in the call to `bulk()`, not in general).  I'm not sure if that is expected or not, but I'd hoped to do some static replacing this way.

Note: need the clone of opts.vars, otherwise every required module will get the same __dirname define, and have other problems.