### PR TITLE
fix transforms that use path

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function (file, opts) {
     
     var sm = staticModule(
         { 'bulk-require': bulkRequire },
-        { vars: vars }
+        { vars: vars, varModules: { path: path } }
     );
     return sm;
     


### PR DESCRIPTION
This PR allows the following to work with `path` in the same way that `brfs` does it.

```javascript
var fixtures = require('bulk-require')(path.join(__dirname, '/fixtures'), '*.json')
```