### PR TITLE
[FIX] return posix format paths on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ module.exports = function (file, opts) {
         var res = bulk(dir, globs, {
             index: opts && opts.index,
             require: function (x) {
-                if (!file) return path.resolve(x);
-                var r = path.relative(filedir, x);
+                if (!file) return path.resolve(x).replace(/\\/g, '/');
+                var r = path.relative(filedir, x).replace(/\\/g, '/');
                 return /^\./.test(r) ? r : './' + r;
             }
         });


### PR DESCRIPTION
Hi, there is problem with bulkify when used on windows, it will build paths in windows format, instead of posix format

i.e when i build provided sample on windows i get paths like this (only those, which are required by bulkify)
browserify -t bulkify glob.js > glob-browser.js

./data\\cats\\index.js
./data\\cats\\meow\\x.js
...
After my fix I will get correct paths
./data/cats/index.js
./data/cats/meow/x.js

